### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://regius.visualstudio.com/d9659b0e-7880-4fdd-9ca6-8ee20023f62d/3d6d75df-34dc-4ad6-b2f0-80c521dd2d59/_apis/work/boardbadge/45c0149c-6a93-4396-ac5d-ef5553a9fb6e)](https://regius.visualstudio.com/d9659b0e-7880-4fdd-9ca6-8ee20023f62d/_boards/board/t/3d6d75df-34dc-4ad6-b2f0-80c521dd2d59/Microsoft.RequirementCategory)
 # helloworld
 This is my first repository on GitHub.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1685](https://regius.visualstudio.com/d9659b0e-7880-4fdd-9ca6-8ee20023f62d/_workitems/edit/1685). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.